### PR TITLE
fix (#10): use POST method instead of DELETE to remove app from shopw…

### DIFF
--- a/extension_manager.go
+++ b/extension_manager.go
@@ -73,7 +73,7 @@ func (e ExtensionManagerService) DeactivateExtension(ctx ApiContext, extType, na
 }
 
 func (e ExtensionManagerService) RemoveExtension(ctx ApiContext, extType, name string) (*http.Response, error) {
-	return e.lifecycleUpdate("RemoveExtension", ctx, fmt.Sprintf("/api/_action/extension/remove/%s/%s", extType, name), http.MethodDelete)
+	return e.lifecycleUpdate("RemoveExtension", ctx, fmt.Sprintf("/api/_action/extension/remove/%s/%s", extType, name), http.MethodPost)
 }
 
 func (e ExtensionManagerService) UploadExtension(ctx ApiContext, extensionZip io.Reader) (*http.Response, error) {


### PR DESCRIPTION
use POST method instead of DELETE to remove app from shopware > 6.6.10.2, as shopware changed the api signature